### PR TITLE
mobile events page navbar fix

### DIFF
--- a/app/components/Hamburger.jsx
+++ b/app/components/Hamburger.jsx
@@ -40,7 +40,7 @@ const Hamburger = ({ isOpen, toggleMenu }) => {
 
   const menuItems = [
     { href: "/", label: "Home" },
-    { href: "/previousevent", label: "Events" },
+    { href: "/event", label: "Events" },
     { href: "/newsletter", label: "Newsletter" },
     { href: "/team", label: "Team" },
   ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the "Events" menu item in the hamburger menu to direct users to the correct "/event" page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->